### PR TITLE
chore: retract v0.8.0

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -13,3 +13,7 @@ require (
 	golang.org/x/mod v0.27.0 // indirect
 	golang.org/x/sync v0.16.0 // indirect
 )
+
+// v0.8.0 was re-tagged after the module proxy had cached the original tag,
+// so the proxy permanently serves stale content for it. Use v0.8.1 instead.
+retract v0.8.0


### PR DESCRIPTION
The v0.8.0 tag was recreated after proxy.golang.org had already cached
the original tag's content, so the proxy permanently serves stale code
for that version. Retract it and release v0.8.1 instead.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>